### PR TITLE
use function syntax instead of lambda when convenient

### DIFF
--- a/react-redux-boilerplate/actions/index.js
+++ b/react-redux-boilerplate/actions/index.js
@@ -6,43 +6,49 @@ import 'whatwg-fetch';
 // Synchronous actions are just Javascript objects that contain a `type` and other metadata. The
 // `type` allows the `store` to distinguish what action is occurring, and, if present, the Redux
 // reducers can use the metadata in other fields to modify the state properly.
-export const incrementCounter = () => ({
-  type: 'INCREMENT_COUNTER',
-});
+export function incrementCounter() {
+  return { type: 'INCREMENT_COUNTER' };
+}
 
-export const fetchingQuote = () => ({
-  type: 'FETCHING_QUOTE',
-});
+export function fetchingQuote() {
+  return { type: 'FETCHING_QUOTE' };
+}
 
-export const receivedQuote = (author, quote) => ({
-  type: 'RECEIVED_QUOTE',
-  author,
-  quote,
-});
+export function receivedQuote(author, quote) {
+  return {
+    type: 'RECEIVED_QUOTE',
+    author,
+    quote,
+  };
+}
 
-export const fetchingQuoteFailed = (err) => ({
-  type: 'FETCHING_QUOTE_FAILED',
-  err,
-});
+export function fetchingQuoteFailed(err) {
+  return {
+    type: 'FETCHING_QUOTE_FAILED',
+    err,
+  };
+}
 
 // Gets a random quote and dispatches actions to update the Redux store correspondingly.
 //
 // Sends Redux actions at each step. This is an asynchronous action that depends on redux-thunk to
 // function correctly.  Asynchronous actions are functions that can dispatch synchronous actions as
 // they please. Hence, this function receives `dispatch` as a parameter.
-export const fetchQuote = () => (dispatch) => {
-  dispatch(fetchingQuote());
-  fetch('/quote').then((response) => {
-    if (response.status >= 200 && response.status < 300) {
-      return response.json();
-    }
+export function fetchQuote() {
+  return (dispatch) => {
+    dispatch(fetchingQuote());
+    fetch('/quote').then((response) => {
+      if (response.status >= 200 && response.status < 300) {
+        return response.json();
+      }
 
-    const error = new Error(response.statusText);
-    error.response = response;
-    throw error;
-  }).then((response) => {
-    dispatch(receivedQuote(response.author, response.quote));
-  }).catch((err) => {
-    dispatch(fetchingQuoteFailed(err));
-  });
-};
+      const error = new Error(response.statusText);
+      error.response = response;
+      throw error;
+    }).then((response) => {
+      dispatch(receivedQuote(response.author, response.quote));
+    }).catch((err) => {
+      dispatch(fetchingQuoteFailed(err));
+    });
+  };
+}

--- a/react-redux-boilerplate/components/CounterSectionView.jsx
+++ b/react-redux-boilerplate/components/CounterSectionView.jsx
@@ -4,13 +4,13 @@ import { Button } from 'clever-components';
 import React, { PropTypes } from 'react';
 
 require('./CounterSection.less');
-const CounterSectionView = ({ counterValue, incrementCounter }) => (
-  <div className="section CounterSection">
+function CounterSectionView({ counterValue, incrementCounter }) {
+  return (<div className="section CounterSection">
     <h2>Counter</h2>
     <p>The current value is: <span className="CounterSection--value">{counterValue}</span></p>
     <Button type="primary" onClick={incrementCounter} value="Increment Counter" />
-  </div>
-);
+  </div>);
+}
 
 CounterSectionView.propTypes = {
   counterValue: PropTypes.number.isRequired,

--- a/react-redux-boilerplate/components/QuoteSectionView.jsx
+++ b/react-redux-boilerplate/components/QuoteSectionView.jsx
@@ -6,7 +6,7 @@ import React, { PropTypes } from 'react';
 
 require('./QuoteSection.less');
 
-const QuoteSectionView = ({ fetchError, fetchingQuote, quote, author, fetchQuote }) => {
+function QuoteSectionView({ fetchError, fetchingQuote, quote, author, fetchQuote }) {
   let content = null;
   if (fetchingQuote) {
     const verb = quote ? 'Finding another' : 'Finding a';
@@ -32,7 +32,7 @@ const QuoteSectionView = ({ fetchError, fetchingQuote, quote, author, fetchQuote
       <Button type="primary" onClick={fetchQuote} value={buttonText} />
     </div>
   );
-};
+}
 
 QuoteSectionView.propTypes = {
   fetchError: PropTypes.object,

--- a/react-redux-boilerplate/containers/CounterSection.js
+++ b/react-redux-boilerplate/containers/CounterSection.js
@@ -5,13 +5,13 @@ import { connect } from 'react-redux';
 import { incrementCounter } from '../actions';
 import CounterSectionView from '../components/CounterSectionView';
 
-const mapStateToProps = (state) => ({
-  counterValue: state.counter.value,
-});
+function mapStateToProps(state) {
+  return { counterValue: state.counter.value };
+}
 
-const mapDispatchToProps = (dispatch) => ({
-  incrementCounter: () => dispatch(incrementCounter()),
-});
+function mapDispatchToProps(dispatch) {
+  return { incrementCounter: () => dispatch(incrementCounter()) };
+}
 
 export default connect(
   mapStateToProps,

--- a/react-redux-boilerplate/containers/QuoteSection.js
+++ b/react-redux-boilerplate/containers/QuoteSection.js
@@ -5,16 +5,18 @@ import { connect } from 'react-redux';
 import { fetchQuote } from '../actions';
 import QuoteSectionView from '../components/QuoteSectionView';
 
-const mapStateToProps = (state) => ({
-  fetchingQuote: state.quote.fetching,
-  quote: state.quote.quote,
-  author: state.quote.author,
-  fetchError: state.quote.fetchError,
-});
+function mapStateToProps(state) {
+  return {
+    fetchingQuote: state.quote.fetching,
+    quote: state.quote.quote,
+    author: state.quote.author,
+    fetchError: state.quote.fetchError,
+  };
+}
 
-const mapDispatchToProps = (dispatch) => ({
-  fetchQuote: () => dispatch(fetchQuote()),
-});
+function mapDispatchToProps(dispatch) {
+  return { fetchQuote: () => dispatch(fetchQuote()) };
+}
 
 export default connect(
   mapStateToProps,


### PR DESCRIPTION
done based on confusion around when to use lambdas and assign to constants vs when to use function declaration
